### PR TITLE
Allow migration to assume role

### DIFF
--- a/.terraform.lock.hcl
+++ b/.terraform.lock.hcl
@@ -1,0 +1,21 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/external" {
+  version = "2.2.2"
+  hashes = [
+    "h1:VUkgcWvCliS0HO4kt7oEQhFD2gcx/59XpwMqxfCU1kE=",
+    "zh:0b84ab0af2e28606e9c0c1289343949339221c3ab126616b831ddb5aaef5f5ca",
+    "zh:10cf5c9b9524ca2e4302bf02368dc6aac29fb50aeaa6f7758cce9aa36ae87a28",
+    "zh:56a016ee871c8501acb3f2ee3b51592ad7c3871a1757b098838349b17762ba6b",
+    "zh:719d6ef39c50e4cffc67aa67d74d195adaf42afcf62beab132dafdb500347d39",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:7fbfc4d37435ac2f717b0316f872f558f608596b389b895fcb549f118462d327",
+    "zh:8ac71408204db606ce63fe8f9aeaf1ddc7751d57d586ec421e62d440c402e955",
+    "zh:a4cacdb06f114454b6ed0033add28006afa3f65a0ea7a43befe45fc82e6809fb",
+    "zh:bb5ce3132b52ae32b6cc005bc9f7627b95259b9ffe556de4dad60d47d47f21f0",
+    "zh:bb60d2976f125ffd232a7ccb4b3f81e7109578b23c9c6179f13a11d125dca82a",
+    "zh:f9540ecd2e056d6e71b9ea5f5a5cf8f63dd5c25394b9db831083a9d4ea99b372",
+    "zh:ffd998b55b8a64d4335a090b6956b4bf8855b290f7554dd38db3302de9c41809",
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -60,13 +60,15 @@ terraform apply
 [//]: # (BEGIN_TF_DOCS)
 ### Requirements
 
-No requirements.
+| Name | Version |
+|------|---------|
+| external | ~> 2.2.2 |
 
 ### Providers
 
 | Name | Version |
 |------|---------|
-| external | n/a |
+| external | 2.2.2 |
 
 ### Modules
 
@@ -83,6 +85,7 @@ No modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | override_template | The override_template map. For information about how to override a container definition check <a href='https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_ContainerOverride.html' target='_blank'>AWS ECS ContainerOverride documentation</a>. | `map(any)` | n/a | yes |
+| assume_role_arn | [OPTIONAL] Allow role to be assumed before creating the ECS container. This is useful to allow running migrations CrossAccount. Defaults: '' | `string` | `""` | no |
 | cluster_name | Cluster name where the migration will run. | `string` | n/a | yes |
 | migration_container_name | Name to be given to the new migration container. | `string` | n/a | yes |
 | region | Cluster AWS region | `string` | n/a | yes |

--- a/main.tf
+++ b/main.tf
@@ -7,5 +7,6 @@ data "external" "run_migration" {
     task_definition_arn      = var.task_definition_arn
     override_template        = base64encode(jsonencode(var.override_template))
     migration_container_name = var.migration_container_name
+    assume_role_arn          = var.assume_role_arn
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -1,3 +1,12 @@
+terraform {
+  required_providers {
+    external = {
+      source = "hashicorp/external"
+     version = "~> 2.2.2"
+    }
+  }
+}
+
 data "external" "run_migration" {
   program = ["/bin/bash", "${path.module}/run-task.sh"]
 

--- a/variables.tf
+++ b/variables.tf
@@ -22,3 +22,9 @@ variable "region" {
   type        = string
   description = "Cluster AWS region"
 }
+
+variable "assume_role_arn" {
+  type        = string
+  description = "[OPTIONAL] Allow role to be assumed before creating the ECS container. This is useful to allow running migrations CrossAccount. Defaults: ''"
+  default     = ""
+}


### PR DESCRIPTION
This PR creates a new optional variable `assume_role_arn` that allows the module to assume a different role.

This is useful the terraform needs to perform a CrossAccount migration or if the current User/Role does not have the proper permissions to execute the task.

If `assume_role_arn` is not given, or is an empty string, then the migration will run with the provider AWS credentials.

